### PR TITLE
use SSL_CTX_use_enc_certificate if (enc_cert->len > 0)

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -535,8 +535,8 @@ ngx_ssl_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *cert,
 
 		 //load enc cert and key for GM by TASS gujq if enc_cert len > 0
     if(enc_cert->len > 0){
-    	if (SSL_CTX_use_certificate_file(ssl->ctx, (char *)enc_cert->data, SSL_FILETYPE_PEM) == 0) {
-    		ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0, "SSL_CTX_use_certificate_file load enc cert(\"%s\") failed", enc_cert->data);
+    	if (SSL_CTX_use_enc_certificate_file(ssl->ctx, (char *)enc_cert->data, SSL_FILETYPE_PEM) == 0) {
+    		ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0, "SSL_CTX_use_enc_certificate_file load enc cert(\"%s\") failed", enc_cert->data);
     		return NGX_ERROR;
     	}
     	


### PR DESCRIPTION
当使用`签名证书`和`加密证书` 同时具备签名和加密功能时， 浏览器会提示错误，具体原因如下：

1. `ngx_ssl_certificate`加载`签名证书`；
2. `SSL_CTX_use_certificate`中调用`ssl_set_cert`；
3. `ssl_set_cert`中对证书进行查询（`ssl_cert_lookup_by_pkey`），获得`index`为`3`，即为ECC`签名`证书`x`；
    - 其中对证书的`ex_kusage`字段和`X509v3_KU_DIGITAL_SIGNATURE`做了`与`运算，满足条件，因此对证书做了赋值，即`c->pkeys[3].x509 = x`；
    - 紧接着，证书的`ex_kusage`字段和`(X509v3_KU_KEY_ENCIPHERMENT | X509v3_KU_DATA_ENCIPHERMENT | X509v3_KU_KEY_AGREEMENT)`做了`与`运算（分支里面存在`i=SSL_PKEY_ECC_ENC`的复制，即 此时`i`值赋值为9），也满足条件，因此也做了赋值，即`c->pkeys[9].x509 = x`，即给`加密证书的位置，赋值了签名证书`，其实是个误操作；
4. `SSL_CTX_use_PrivateKey`中调用`ssl_set_pkey`,设置` c->pkeys[3].privatekey = pkey` 这个是正常操作，将idx=3的私钥写入对应的位置；
5. 然后进入判断`加密`证书步骤，使用`SSL_CTX_use_certificate_file`,内部其实调用的也是`SSL_CTX_use_certificate`，进而调用了`ssl_set_cert`；
6. 由于`加密`证书中也支持`签名`，因此证书的`ex_kusage`字段`X509v3_KU_DIGITAL_SIGNATURE`的`与`操作也为真，但是此时证书进行查询（`ssl_cert_lookup_by_pkey`）获得的`idx`依然是`3`,导致`X509_check_private_key`中证书参数是`签名证书的证书`，私钥参数是`加密证书的私钥`，因此导致check失败，然后`c->pkeys[3].privatekey = NULL;`，所以后面会看到`idx=3的证书私钥为NULL`；
7. 然后加密证书支持加密功能，即证书的`ex_kusage`字段和`(X509v3_KU_KEY_ENCIPHERMENT | X509v3_KU_DATA_ENCIPHERMENT | X509v3_KU_KEY_AGREEMENT)`做了`与`运算（此时`i`值赋值为9），也满足条件，因此也做了赋值，即`c->pkeys[9].x509 = x`；
    - 相当于这次的证书赋值操作，把`第3步`赋值错误的操作进行了修正；
8. 最后使用`SSL_CTX_use_enc_PrivateKey`中的`ssl_set_enc_pkey`，将`加密`证书的私钥写入正确的位置（idx=9）。

因此，问题就在于，由于两张证书均有签名和加密功能，在openssl库上的实现存在混淆，导致最终`ssl-ctx-certs-pkeys`数组中的idx=3的私钥丢失。
当把证书换成一样的时候，由于私钥和证书一样，X509_check是通过的，因此没有问题。

然后准备修改TASSL-1.1.1b时，发现已经实现了`SSL_CTX_use_enc_certificate`，直接替换后，测试正常。

虽然理论上， 加密证书应该只有加密的usage， 签名证书只需要签名的usage，但是考虑兼容性，建议还是使用 SSL_CTX_use_enc_certificate 进行替换。